### PR TITLE
fix: persist assistant response when user aborts during streaming

### DIFF
--- a/classes/ai/class.GWDG.php
+++ b/classes/ai/class.GWDG.php
@@ -75,10 +75,24 @@ class GWDG extends LLM
         $responseContent = '';
 
         if ($this->isStreaming()) {
+            ignore_user_abort(true);
+            set_time_limit(120);
+            if (function_exists('session_write_close')) {
+                session_write_close();
+            }
+
+            if (!headers_sent()) {
+                header('Content-Type: text/event-stream');
+                header('Cache-Control: no-cache');
+                header('X-Accel-Buffering: no');
+            }
+            while (ob_get_level() > 0) {
+                ob_end_flush();
+            }
+
             curl_setopt($curlSession, CURLOPT_WRITEFUNCTION, function ($curlSession, $chunk) use (&$responseContent) {
                 $responseContent .= $chunk;
                 echo $chunk;
-                ob_flush();
                 flush();
                 return strlen($chunk);
             });

--- a/classes/ai/class.OpenAI.php
+++ b/classes/ai/class.OpenAI.php
@@ -82,10 +82,24 @@ class OpenAI extends LLM
         $responseContent = '';
 
         if ($this->isStreaming()) {
+            ignore_user_abort(true);
+            set_time_limit(120);
+            if (function_exists('session_write_close')) {
+                session_write_close();
+            }
+
+            if (!headers_sent()) {
+                header('Content-Type: text/event-stream');
+                header('Cache-Control: no-cache');
+                header('X-Accel-Buffering: no');
+            }
+            while (ob_get_level() > 0) {
+                ob_end_flush();
+            }
+
             curl_setopt($curlSession, CURLOPT_WRITEFUNCTION, function ($curlSession, $chunk) use (&$responseContent) {
                 $responseContent .= $chunk;
                 echo $chunk;
-                ob_flush();
                 flush();
                 return strlen($chunk);
             });

--- a/classes/class.ilObjAIChatGUI.php
+++ b/classes/class.ilObjAIChatGUI.php
@@ -585,6 +585,14 @@ class ilObjAIChatGUI extends ilObjectPluginGUI
 
                     $chat->setMaxMessages($this->object->getAIChat()->getMaxMemoryMessages());
 
+                    if ($this->object->getAIChat()->isStreamingEnabled()) {
+                        $message->save();
+                        $chat->save();
+
+                        $this->object->getAIChat()->getLLMResponse($chat);
+                        exit;
+                    }
+
                     $retval = array(
                         "message" => $message->toArray(),
                         "llmresponse" => $this->object->getAIChat()->getLLMResponse($chat)->toArray()

--- a/classes/objects/class.AIChat.php
+++ b/classes/objects/class.AIChat.php
@@ -475,6 +475,18 @@ class AIChat
     /**
      * @throws AIChatException
      */
+    public function isStreamingEnabled(): bool
+    {
+        switch ($this->getServiceToUse()) {
+            case "openai":
+                return (bool) $this->isOpenaiStreaming();
+            case "gwdg":
+                return (bool) $this->isGwdgStreaming();
+            default:
+                return false;
+        }
+    }
+
     public function getLLMResponse(Chat $chat): Message
     {
         $llm_response = $this->llm->sendChat($chat);

--- a/plugin.php
+++ b/plugin.php
@@ -21,7 +21,7 @@
 
 $id = 'xaic';
 
-$version = '10.0.1';
+$version = '10.0.2';
 
 $ilias_min_version = '10.0';
 $ilias_max_version = '10.999';


### PR DESCRIPTION
## Summary

  In streaming mode, closing the tab killed the script before the assistant
  reply could be saved. Add `ignore_user_abort(true)`, `set_time_limit(120)`
  and `session_write_close()` in `OpenAI` and `GWDG` so the response is
  always persisted. Bumps version to 10.0.2.