### PR TITLE
Ilias11 dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,20 +42,15 @@ This plugin has been developed to allow the use of different API-keys for differ
 - In case you want to connect with GPT on the cloud, AIChat requires at least one [OpenAI](https://openai.com) GPT API key to work on your ILIAS platform.
 
 ### Installation steps
-
-In ILIAS 11 the `Customizing` directory now lives inside the `public/` document root.
-
-1. Create the plugin subdirectories if they do not exist yet:
-```bash
-mkdir -p public/Customizing/global/plugins/Services/Repository/RepositoryObject
-```
-2. From `public/Customizing/global/plugins/Services/Repository/RepositoryObject/`, execute:
+1. Create subdirectories, if necessary for public/Customizing/global/plugins/Services/Repository/RepositoryObject/
+2. In public/Customizing/global/plugins/Services/Repository/RepositoryObject/
+3. Then, execute:
 ```bash
 git clone https://github.com/surlabs/AIChatForILIAS.git ./AIChat
 cd AIChat
 git checkout ilias11
 ```
-3. AI Chat uses the ILIAS composer autoloader functionality so, after installing or updating the plugin, ensure you run on the ILIAS root folder:
+3. AI Chat uses the ILIAS composer autoloader functionality so, after installing or updating the plugin, ensure you run on the ILIAS root folder
 ```bash
 composer du
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![AIChat](https://github.com/user-attachments/assets/634be0e5-58c3-4b58-a0e9-f4f97b8811d6)
 
-# AI Chat Repository Object Plugin for ILIAS 10
+# AI Chat Repository Object Plugin for ILIAS 11
 
 Welcome to the official repository for AI Chat Repository Object Plugin for ILIAS
 This Open Source ILIAS Plugin is created and maintained by [SURLABS](https://www.surlabs.com)
@@ -38,19 +38,24 @@ This plugin has been developed to allow the use of different API-keys for differ
 ## Installation & Update
 
 ### Software Requirements
-- AI Chat requires [PHP](https://php.net) versions 8.2 to work properly on your ILIAS 10 platform
+- AI Chat requires [PHP](https://php.net) versions 8.2 or higher to work properly on your ILIAS 11 platform
 - In case you want to connect with GPT on the cloud, AIChat requires at least one [OpenAI](https://openai.com) GPT API key to work on your ILIAS platform.
 
 ### Installation steps
-1. Create subdirectories, if necessary for public/Customizing/global/plugins/Services/Repository/RepositoryObject/
-2. In public/Customizing/global/plugins/Services/Repository/RepositoryObject/ 
-3. Then, execute:
+
+In ILIAS 11 the `Customizing` directory now lives inside the `public/` document root.
+
+1. Create the plugin subdirectories if they do not exist yet:
+```bash
+mkdir -p public/Customizing/global/plugins/Services/Repository/RepositoryObject
+```
+2. From `public/Customizing/global/plugins/Services/Repository/RepositoryObject/`, execute:
 ```bash
 git clone https://github.com/surlabs/AIChatForILIAS.git ./AIChat
 cd AIChat
-git checkout ilias10
+git checkout ilias11
 ```
-3. AI Chat uses the ILIAS composer autoloader functionality so, after installing or update the plugin, ensure you run on the ILIAS root folder
+3. AI Chat uses the ILIAS composer autoloader functionality so, after installing or updating the plugin, ensure you run on the ILIAS root folder:
 ```bash
 composer du
 ```

--- a/classes/ai/class.GWDG.php
+++ b/classes/ai/class.GWDG.php
@@ -75,10 +75,24 @@ class GWDG extends LLM
         $responseContent = '';
 
         if ($this->isStreaming()) {
+            ignore_user_abort(true);
+            set_time_limit(120);
+            if (function_exists('session_write_close')) {
+                session_write_close();
+            }
+
+            if (!headers_sent()) {
+                header('Content-Type: text/event-stream');
+                header('Cache-Control: no-cache');
+                header('X-Accel-Buffering: no');
+            }
+            while (ob_get_level() > 0) {
+                ob_end_flush();
+            }
+
             curl_setopt($curlSession, CURLOPT_WRITEFUNCTION, function ($curlSession, $chunk) use (&$responseContent) {
                 $responseContent .= $chunk;
                 echo $chunk;
-                ob_flush();
                 flush();
                 return strlen($chunk);
             });

--- a/classes/ai/class.OpenAI.php
+++ b/classes/ai/class.OpenAI.php
@@ -82,10 +82,24 @@ class OpenAI extends LLM
         $responseContent = '';
 
         if ($this->isStreaming()) {
+            ignore_user_abort(true);
+            set_time_limit(120);
+            if (function_exists('session_write_close')) {
+                session_write_close();
+            }
+
+            if (!headers_sent()) {
+                header('Content-Type: text/event-stream');
+                header('Cache-Control: no-cache');
+                header('X-Accel-Buffering: no');
+            }
+            while (ob_get_level() > 0) {
+                ob_end_flush();
+            }
+
             curl_setopt($curlSession, CURLOPT_WRITEFUNCTION, function ($curlSession, $chunk) use (&$responseContent) {
                 $responseContent .= $chunk;
                 echo $chunk;
-                ob_flush();
                 flush();
                 return strlen($chunk);
             });

--- a/classes/class.ilObjAIChatAccess.php
+++ b/classes/class.ilObjAIChatAccess.php
@@ -63,7 +63,6 @@ class ilObjAIChatAccess extends ilObjectPluginAccess
 
     public static function getConditionOperators() : array
     {
-        include_once './Services/Conditions/classes/class.ilConditionHandler.php';
         return array(
             ilConditionHandler::OPERATOR_FAILED,
             ilConditionHandler::OPERATOR_PASSED

--- a/classes/class.ilObjAIChatGUI.php
+++ b/classes/class.ilObjAIChatGUI.php
@@ -585,6 +585,14 @@ class ilObjAIChatGUI extends ilObjectPluginGUI
 
                     $chat->setMaxMessages($this->object->getAIChat()->getMaxMemoryMessages());
 
+                    if ($this->object->getAIChat()->isStreamingEnabled()) {
+                        $message->save();
+                        $chat->save();
+
+                        $this->object->getAIChat()->getLLMResponse($chat);
+                        exit;
+                    }
+
                     $retval = array(
                         "message" => $message->toArray(),
                         "llmresponse" => $this->object->getAIChat()->getLLMResponse($chat)->toArray()

--- a/classes/objects/class.AIChat.php
+++ b/classes/objects/class.AIChat.php
@@ -472,6 +472,18 @@ class AIChat
         }
     }
     
+    public function isStreamingEnabled(): bool
+    {
+        switch ($this->getServiceToUse()) {
+            case "openai":
+                return (bool) $this->isOpenaiStreaming();
+            case "gwdg":
+                return (bool) $this->isGwdgStreaming();
+            default:
+                return false;
+        }
+    }
+
     /**
      * @throws AIChatException
      */

--- a/plugin.php
+++ b/plugin.php
@@ -21,10 +21,10 @@
 
 $id = 'xaic';
 
-$version = '10.0.1';
+$version = '11.0.0';
 
-$ilias_min_version = '10.0';
-$ilias_max_version = '10.999';
+$ilias_min_version = '11.0';
+$ilias_max_version = '11.999';
 
 $responsible = 'Jesus Copado';
 $responsible_mail = 'jcopado@surlabs.com';


### PR DESCRIPTION
  ## Summary

  Initial release of the AIChat plugin for ILIAS 11.

  ## Changes

  - `plugin.php`: version `11.0.0`, ILIAS min/max `11.0` – `11.999`.
  - `class.ilObjAIChatAccess.php`: drop legacy `include_once` of
    `ilConditionHandler` (resolved by the composer autoloader in 11).
  - `README.md`: install instructions point to the `ilias11` branch and
    PHP 8.2+ on ILIAS 11.
